### PR TITLE
Change submodule URLs to use SSH instead of HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Quaver.API"]
 	path = Quaver.API
-	url = https://github.com/Quaver/Quaver.API
+	url = git@github.com:Quaver/Quaver.API.git
 [submodule "handlers/scores/chicken"]
 	path = handlers/scores/chicken
-	url = https://github.com/Quaver/chicken
+	url = git@github.com:Quaver/chicken.git


### PR DESCRIPTION
I couldn't clone the submodules properly through HTTPS so I changed them to use SSH /shrug