### PR TITLE
Fix how we parse client IP

### DIFF
--- a/utils/requests.go
+++ b/utils/requests.go
@@ -1,14 +1,42 @@
 package utils
 
-import "github.com/gin-gonic/gin"
+import (
+	"net"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
 
 // GetIpFromRequest Gets the client's proper ip address from a request.
 func GetIpFromRequest(c *gin.Context) string {
-	// Running under NGINX
-	ip := c.GetHeader("X-Forwarded-For")
+	headers := []string{
+		"CF-Connecting-IP",
+		"X-Real-IP",
+	}
 
-	if ip != "" {
-		return ip
+	for _, h := range headers {
+		if ip := strings.TrimSpace(c.GetHeader(h)); ip != "" {
+			if parsed := net.ParseIP(ip); parsed != nil {
+				return parsed.String()
+			}
+		}
+	}
+
+	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
+		ip := strings.TrimSpace(strings.Split(xff, ",")[0])
+		if parsed := net.ParseIP(ip); parsed != nil {
+			return parsed.String()
+		}
+	}
+
+	if host, _, err := net.SplitHostPort(strings.TrimSpace(c.Request.RemoteAddr)); err == nil {
+		if parsed := net.ParseIP(host); parsed != nil {
+			return parsed.String()
+		}
+	}
+
+	if parsed := net.ParseIP(strings.TrimSpace(c.Request.RemoteAddr)); parsed != nil {
+		return parsed.String()
 	}
 
 	return "::1"

--- a/utils/requests.go
+++ b/utils/requests.go
@@ -30,5 +30,5 @@ func GetIpFromRequest(c *gin.Context) string {
 		return ip.String()
 	}
 
-	return ""
+	return "::1"
 }

--- a/utils/requests.go
+++ b/utils/requests.go
@@ -9,35 +9,26 @@ import (
 
 // GetIpFromRequest Gets the client's proper ip address from a request.
 func GetIpFromRequest(c *gin.Context) string {
-	headers := []string{
-		"CF-Connecting-IP",
-		"X-Real-IP",
+	if ip := net.ParseIP(strings.TrimSpace(c.GetHeader("CF-Connecting-IP"))); ip != nil {
+		return ip.String()
 	}
 
-	for _, h := range headers {
-		if ip := strings.TrimSpace(c.GetHeader(h)); ip != "" {
-			if parsed := net.ParseIP(ip); parsed != nil {
-				return parsed.String()
+	if ip := net.ParseIP(strings.TrimSpace(c.GetHeader("X-Real-IP"))); ip != nil {
+		return ip.String()
+	}
+
+	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
+		for _, part := range strings.Split(xff, ",") {
+			if ip := net.ParseIP(strings.TrimSpace(part)); ip != nil {
+				return ip.String()
 			}
 		}
 	}
 
-	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
-		ip := strings.TrimSpace(strings.Split(xff, ",")[0])
-		if parsed := net.ParseIP(ip); parsed != nil {
-			return parsed.String()
-		}
+	host, _, _ := net.SplitHostPort(c.Request.RemoteAddr)
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.String()
 	}
 
-	if host, _, err := net.SplitHostPort(strings.TrimSpace(c.Request.RemoteAddr)); err == nil {
-		if parsed := net.ParseIP(host); parsed != nil {
-			return parsed.String()
-		}
-	}
-
-	if parsed := net.ParseIP(strings.TrimSpace(c.Request.RemoteAddr)); parsed != nil {
-		return parsed.String()
-	}
-
-	return "::1"
+	return ""
 }


### PR DESCRIPTION
Since the header we use by default, can have multiple IP's attached to it https://developers.cloudflare.com/fundamentals/reference/http-headers/#x-forwarded-for we cannot use it directly.

For now we will default to using CF-Connecting-IP first, if that fails X-Real-IP and then we will default to X-Forwarded-For, but we will split it and only take the first IP from it, which should be the client IP.

Code has not been tested in production env